### PR TITLE
Add fix to prevent field name from being directly injected into tag

### DIFF
--- a/QRCodeExternalModule.php
+++ b/QRCodeExternalModule.php
@@ -52,10 +52,12 @@ class QRCodeExternalModule extends \ExternalModules\AbstractExternalModule {
         $js = [];
         foreach ($tags as $tag) {
             if ($tag["type"] == "file") {
-                $js[] = "$('#{$tag["field"]}-linknew a.fileuploadlink').remove()";
-                $js[] = "$('#{$tag["field"]}-linknew span').not('.edoc-link').remove()";
+				$tagField = preg_replace("/[^a-zA-Z0-9_]/","",$tag["field"]);
+                $js[] = "$('#{$tagField}-linknew a.fileuploadlink').remove()";
+                $js[] = "$('#{$tagField}-linknew span').not('.edoc-link').remove()";
             }
         }
+		
         if (count($js)) {
             print "<script>$(function() { " . join("; ", $js) . " });</script>";
         }


### PR DESCRIPTION
Issue if field_name contains non-field name characters. "');alert('test');" for example. Shouldn't happen in UI, but want to prevent the hole should it happen. REDCap doesn't filter those characters out from DB field_name in Project class, so we should before displaying.